### PR TITLE
feat: Add configurable LangChain text chunking

### DIFF
--- a/service-clients/pom.xml
+++ b/service-clients/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>failsafe</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>

--- a/service-clients/src/main/java/com/google/cloud/pso/rag/content/Chunks.java
+++ b/service-clients/src/main/java/com/google/cloud/pso/rag/content/Chunks.java
@@ -23,9 +23,9 @@ import java.util.concurrent.CompletableFuture;
 /** */
 public interface Chunks {
 
-  sealed interface ChunkRequest permits Gemini.ChunkRequest {}
+  sealed interface ChunkRequest permits Gemini.ChunkRequest, LangChainChunks.LangChainRecursiveCharacterSplitterRequest {}
 
-  sealed interface ChunkResponse permits Gemini.ChunkResponse {
+  sealed interface ChunkResponse permits Gemini.ChunkResponse, LangChainChunks.LangChainChunkResponse {
     List<String> chunks();
   }
 
@@ -33,6 +33,7 @@ public interface Chunks {
       ChunkRequest request) {
     return switch (request) {
       case Gemini.ChunkRequest geminiRequest -> Gemini.extractChunks(geminiRequest);
+      case LangChainChunks.LangChainRecursiveCharacterSplitterRequest langChainRequest -> LangChainChunks.extractChunks(langChainRequest);
     };
   }
 }

--- a/service-clients/src/main/java/com/google/cloud/pso/rag/content/LangChainChunks.java
+++ b/service-clients/src/main/java/com/google/cloud/pso/rag/content/LangChainChunks.java
@@ -1,0 +1,68 @@
+package com.google.cloud.pso.rag.content;
+
+import com.google.cloud.pso.rag.common.InteractionHelper;
+import com.google.cloud.pso.rag.executor.Result;
+import com.google.cloud.pso.rag.util.ErrorResponse;
+import dev.langchain4j.data.document.splitter.RecursiveCharacterTextSplitter;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.data.document.DocumentSplitters;
+// import dev.langchain4j.model.openai.OpenAiTokenizer; // Not used for local splitting
+import java.util.concurrent.CompletableFuture;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class LangChainChunks {
+
+    private LangChainChunks() {}
+
+    // modelName is not used for local splitting but kept for consistency with Gemini.ChunkRequest
+    public record LangChainRecursiveCharacterSplitterRequest(
+            String text,
+            String modelName,
+            Optional<Integer> maxSegmentSizeInChars,
+            Optional<Integer> maxOverlapSizeInChars) implements Chunks.ChunkRequest {
+        @Override
+        public String content() { // Keep content() for compatibility with Chunks.ChunkRequest if it's used elsewhere.
+            return text;
+        }
+    }
+
+    public record LangChainChunkResponse(List<String> chunks) implements Chunks.ChunkResponse {
+        @Override
+        public List<String> chunks() {
+            return chunks;
+        }
+    }
+
+    public static CompletableFuture<Result<? extends Chunks.ChunkResponse, ErrorResponse>> extractChunks(LangChainRecursiveCharacterSplitterRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            int segmentSize = request.maxSegmentSizeInChars().orElse(500);
+            int overlapSize = request.maxOverlapSizeInChars().orElse(50);
+
+            // OpenAiTokenizer could be used here if we want to split by tokens:
+            // RecursiveCharacterTextSplitter splitter = DocumentSplitters.recursive(segmentSize, overlapSize, new OpenAiTokenizer(request.modelName()));
+            RecursiveCharacterTextSplitter splitter = DocumentSplitters.recursive(segmentSize, overlapSize);
+
+            List<TextSegment> segments = splitter.split(request.text());
+            List<String> chunks = segments.stream()
+                                          .map(TextSegment::text)
+                                          .collect(Collectors.toList());
+
+            return Result.success(new LangChainChunkResponse(chunks));
+        }, InteractionHelper.EXEC)
+        .exceptionally(error -> {
+            // You can log the error here if needed, e.g., using a logger
+            // LOGGER.error("Error during LangChain chunking", error);
+            // Ensure the ErrorResponse constructor is used if it expects a message and a Throwable.
+            // If ErrorResponse is a record/class that simply takes a string, then adjust accordingly.
+            // Assuming ErrorResponse can be created with a message and a throwable for context.
+            // If not, new ErrorResponse("Error during LangChain chunking: " + error.getMessage()) might be more appropriate
+            // or just new ErrorResponse("Error during LangChain chunking.")
+            // For now, sticking to the simpler new ErrorResponse("message", throwable) if that's how it's defined.
+            // The previous code used: new ErrorResponse("Error during LangChain chunking: " + e.getMessage(), e)
+            // So, to keep it consistent:
+            return Result.failure(new ErrorResponse("Error during LangChain chunking: " + error.getMessage(), error));
+        });
+    }
+}

--- a/service-clients/src/test/java/com/google/cloud/pso/rag/content/LangChainChunksTest.java
+++ b/service-clients/src/test/java/com/google/cloud/pso/rag/content/LangChainChunksTest.java
@@ -1,0 +1,135 @@
+package com.google.cloud.pso.rag.content;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.cloud.pso.rag.executor.Result;
+import com.google.cloud.pso.rag.util.ErrorResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+class LangChainChunksTest {
+
+    private final String sampleText700 =
+        "This is a long string designed to test the chunking functionality of the LangChainChunks class. " + // 100
+        "It needs to be sufficiently lengthy to be split into multiple segments by the RecursiveCharacterTextSplitter. " + // 110
+        "The splitter is configured with a maximum segment size of 500 characters and an overlap of 50 characters. " + // 108
+        "Therefore, this string, which is intentionally made to be 700 characters long, should ideally result in two distinct chunks. " + // 122
+        "The first chunk should be approximately 500 characters long, and the second chunk should contain the remaining part of the text. " + // 130
+        "Crucially, there should be an overlap of 50 characters between the end of the first chunk and the beginning of the second chunk. " + // 130
+        "This overlap ensures context is maintained across chunks."; // 60
+
+    @Test
+    void testExtractChunks_simpleText_shouldReturnChunks() throws ExecutionException, InterruptedException {
+        assertEquals(700, sampleText700.length(), "Sample text length should be 700 characters for this test.");
+
+        LangChainChunks.LangChainRecursiveCharacterSplitterRequest request =
+            new LangChainChunks.LangChainRecursiveCharacterSplitterRequest(sampleText700, "default-model", Optional.empty(), Optional.empty());
+
+        CompletableFuture<Result<? extends Chunks.ChunkResponse, ErrorResponse>> futureResult =
+                LangChainChunks.extractChunks(request);
+
+        Result<? extends Chunks.ChunkResponse, ErrorResponse> result = futureResult.get();
+
+        assertTrue(result.isSuccess(), "The chunking process should be successful.");
+        assertNotNull(result.getSuccessValue(), "The success value (ChunkResponse) should not be null.");
+        
+        Chunks.ChunkResponse response = result.getSuccessValue();
+        List<String> chunks = response.chunks();
+
+        assertNotNull(chunks, "The list of chunks should not be null.");
+        assertFalse(chunks.isEmpty(), "The list of chunks should not be empty.");
+        
+        // With a 700 char string, default 500 char limit, and default 50 char overlap:
+        // Chunk 1: text[0...499]
+        // Chunk 2: text[450...699] 
+        assertEquals(2, chunks.size(), "Expected 2 chunks for a 700 character string with 500/50 splitting.");
+
+        String chunk1 = chunks.get(0);
+        String chunk2 = chunks.get(1);
+
+        assertEquals(500, chunk1.length(), "Chunk 1 length should be 500 characters.");
+        assertEquals(250, chunk2.length(), "Chunk 2 length should be 250 characters (700 - 500 + 50 overlap).");
+
+
+        String overlapFromChunk1 = chunk1.substring(chunk1.length() - 50);
+        String overlapInChunk2 = chunk2.substring(0, 50);
+        assertEquals(overlapFromChunk1, overlapInChunk2, "The overlap between chunk 1 and chunk 2 should match.");
+
+        assertEquals(sampleText700, chunk1.substring(0, 500 - 50) + chunk2, "Combined chunks (accounting for overlap) should match original text");
+    }
+
+    @Test
+    void testExtractChunks_customSizeAndOverlap_shouldReturnChunksAsConfigured() throws ExecutionException, InterruptedException {
+        assertEquals(700, sampleText700.length(), "Sample text length should be 700 characters for this test.");
+        int customChunkSize = 300;
+        int customOverlap = 30;
+
+        LangChainChunks.LangChainRecursiveCharacterSplitterRequest request =
+            new LangChainChunks.LangChainRecursiveCharacterSplitterRequest(sampleText700, "custom-model", Optional.of(customChunkSize), Optional.of(customOverlap));
+
+        CompletableFuture<Result<? extends Chunks.ChunkResponse, ErrorResponse>> futureResult =
+                LangChainChunks.extractChunks(request);
+        Result<? extends Chunks.ChunkResponse, ErrorResponse> result = futureResult.get();
+
+        assertTrue(result.isSuccess(), "The chunking process with custom sizes should be successful.");
+        assertNotNull(result.getSuccessValue(), "The success value (ChunkResponse) should not be null for custom sizes.");
+
+        Chunks.ChunkResponse response = result.getSuccessValue();
+        List<String> chunks = response.chunks();
+
+        assertNotNull(chunks, "The list of chunks should not be null for custom sizes.");
+        
+        // Chunk 1: 0-299 (300 chars)
+        // Chunk 2: 270-569 (300 chars) (starts at 300-30=270, ends at 270+300=570)
+        // Chunk 3: 540-699 (160 chars) (starts at 570-30=540, ends at 540+remaining=540+160=700)
+        assertEquals(3, chunks.size(), "Expected 3 chunks for 700 chars with 300/30 splitting.");
+
+        String chunk1 = chunks.get(0);
+        String chunk2 = chunks.get(1);
+        String chunk3 = chunks.get(2);
+
+        assertEquals(customChunkSize, chunk1.length(), "Chunk 1 length should be custom chunk size.");
+        assertEquals(customChunkSize, chunk2.length(), "Chunk 2 length should be custom chunk size.");
+        assertEquals(sampleText700.length() - (2 * customChunkSize) + (2 * customOverlap) , chunk3.length(), "Chunk 3 length should be the remainder."); // 700 - 600 + 60 = 160
+
+        String overlap1to2FromChunk1 = chunk1.substring(customChunkSize - customOverlap);
+        String overlap1to2InChunk2 = chunk2.substring(0, customOverlap);
+        assertEquals(overlap1to2FromChunk1, overlap1to2InChunk2, "Overlap between chunk 1 and 2 should match.");
+
+        String overlap2to3FromChunk2 = chunk2.substring(customChunkSize - customOverlap);
+        String overlap2to3InChunk3 = chunk3.substring(0, customOverlap);
+        assertEquals(overlap2to3FromChunk2, overlap2to3InChunk3, "Overlap between chunk 2 and 3 should match.");
+        
+        String reconstructedText = chunk1.substring(0, customChunkSize - customOverlap) + 
+                                   chunk2.substring(0, customChunkSize - customOverlap) + 
+                                   chunk3;
+        assertEquals(sampleText700, reconstructedText, "Combined chunks (accounting for overlap) should match original text with custom sizes.");
+    }
+
+    @Test
+    void testExtractChunks_textShorterThanSize_shouldReturnSingleChunk() throws ExecutionException, InterruptedException {
+        String shortText = "This is a short text, much less than 500 characters."; // 52 chars
+        assertEquals(52, shortText.length());
+
+        LangChainChunks.LangChainRecursiveCharacterSplitterRequest request =
+            new LangChainChunks.LangChainRecursiveCharacterSplitterRequest(shortText, "short-text-model", Optional.empty(), Optional.empty());
+
+        CompletableFuture<Result<? extends Chunks.ChunkResponse, ErrorResponse>> futureResult =
+                LangChainChunks.extractChunks(request);
+        Result<? extends Chunks.ChunkResponse, ErrorResponse> result = futureResult.get();
+
+        assertTrue(result.isSuccess(), "Chunking short text should be successful.");
+        assertNotNull(result.getSuccessValue(), "Success value for short text should not be null.");
+
+        Chunks.ChunkResponse response = result.getSuccessValue();
+        List<String> chunks = response.chunks();
+
+        assertNotNull(chunks, "Chunks list for short text should not be null.");
+        assertEquals(1, chunks.size(), "Expected 1 chunk for text shorter than default chunk size.");
+        assertEquals(shortText, chunks.get(0), "The single chunk should match the original short text.");
+        assertEquals(shortText.length(), chunks.get(0).length(), "The single chunk length should match original short text length.");
+    }
+}


### PR DESCRIPTION
This commit enhances text chunking capabilities using LangChain4j, introducing configurability for chunk size and overlap.

Key changes:
- I renamed `LangChainChunkRequest` to `LangChainRecursiveCharacterSplitterRequest` for clarity.
- I modified `LangChainRecursiveCharacterSplitterRequest` to include optional parameters (`maxSegmentSizeInChars`, `maxOverlapSizeInChars`) allowing customization of the recursive character splitting behavior. Defaults (500 chars size, 50 chars overlap) are used if not specified.
- I updated `LangChainChunks.java` to utilize these parameters from the request when invoking `DocumentSplitters.recursive()`.
- I ensured `LangChainChunks.extractChunks` continues to perform operations asynchronously on a virtual thread via `InteractionHelper.EXEC`.
- Error handling uses `CompletableFuture.exceptionally` for robustness.
- I updated `Chunks.java` to reflect the new request record name.
- I added `dev.langchain4j:langchain4j:1.0.0` as a dependency in `service-clients/pom.xml`.
- I significantly updated `LangChainChunksTest.java` to:
    - Use the new request record.
    - Verify the default chunking behavior.
    - Add new tests for custom chunk sizes and overlaps.
    - Add a test for texts shorter than the configured chunk size.

This provides a more flexible and robust LangChain-based text splitting alternative to the existing Gemini-based chunking.