### PR TITLE
Bugs in deployment scripts and terraform 

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -283,7 +283,7 @@ output "embeddings_models" {
 }
 
 output "vector_storages" {
-  value = one(var.vector_storages)
+  value = tolist(var.vector_storages)[0]
 }
 
 output "chunkers" {

--- a/start.sh
+++ b/start.sh
@@ -18,8 +18,8 @@ then
   OTHER=$4
 fi
 
-source deploy_infra.sh $PROJECT_ID $STATE_BUCKET $RUN_NAME $REGION
-
 source build.sh $PROJECT_ID $RUN_NAME $REGION 
+
+source deploy_infra.sh $PROJECT_ID $STATE_BUCKET $RUN_NAME $REGION
 
 source deploy_pipeline.sh $PROJECT_ID $RUN_NAME $REGION $OTHER


### PR DESCRIPTION
Several bug fixes have been implemented on Terraform that where affecting the deployment of the solution with AlloyDB:

1. Executing build.sh before deploy_infra.sh to make sure services and service clients have been installed before building container image for Cloud Run

2. The vector_storages output now shows the first element of var.vector_storages


